### PR TITLE
Add email-to-lunchmoney tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ DISCLAIMER: The projects listed here are built and maintained by members of the 
 * [LunchSync: Sync Apple Wallet transactions to Lunch Money](https://github.com/milanave/LunchSync) - Available on [Test Flight](https://testflight.apple.com/join/mF8JEHqk) - (by LittleBlueBug).
 
 ## Transaction Update Tools
+* [email-to-lunchmoney: Parse receipt emails into meaningful metadata in Lunch Money](https://github.com/evanpurkhiser/email-to-lunchmoney) - Cloudflare worker that automatically adds metadata from receipt emails (Amazon, Lyft, Cloudflare, Apple) to Lunch Money transactions. Supports splitting Amazon orders by item and adding ride details to Lyft transactions - (by Evan Purkhiser).
 * [lunchmoney-amazon: Categorize, and add order numbers, to Amazon transactions in LunchMoney](https://github.com/iloveitaly/lunchmoney-amazon) - for javascript fans (by Michael Bianco).
 * [lunchable-primelunch: LunchMoney Amazon Transaction Updater](https://github.com/juftin/lunchable-primelunch) - for python fans (by Justin Flannery).
 


### PR DESCRIPTION
This tool automates the enrichment of Lunch Money transactions with detailed metadata from receipt emails. It solves a common pain point where users see generic merchant names but can't easily remember what they actually purchased. The tool currently supports Amazon (with automatic order splitting by item), Lyft (with route details), Cloudflare invoices, and Apple receipts. It's actively maintained, well-documented, and uses a robust architecture (Cloudflare Workers with D1 database) that processes emails via Gmail filters and a Google Apps Script integration. The tool meets all quality standards with comprehensive documentation, clear setup instructions, and plans for expansion to support Uber and Square receipts.

**Checklist:**
- [x] I have added my resource in alphabetical order
- [x] I know that this resource was not listed before
- [x] I have added a link to the source code repo
- [x] I have checked my resource is properly documented
- [x] I have added a synthetic description of my resource
- [x] I have read the Contribution guidelines and Quality standards