### PR TITLE
Add lunchmoney-mcp-cloudflare to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Connect AI assistants like Claude to your Lunch Money data using the Model Conte
 * [lunchmoney-mcp](https://github.com/akutishevsky/lunchmoney-mcp) - A Model Context Protocol server that covers 100% of the Lunch Money API functionality with easy install and logging. - (by akutishevsky)
   * [Spotlight Blog](https://lunchmoney.app/blog/2025-10-09-community-newsletter)
 * [lunchmoney-mcp-v2](https://github.com/ConnorDBurge/lunchmoney-mcp-v2) - MCP server built on the official Lunch Money v2 SDK. - (by Conner Burge)
+* [lunchmoney-mcp-cloudflare](https://github.com/bm1549/lunchmoney-mcp-cloudflare) - Deploys akutishevsky/lunchmoney-mcp to a Cloudflare Worker with Google OAuth, exposing it as a remote MCP server so the Claude mobile app (which can't use stdio servers) can connect as a custom connector. One-command setup wizard; fits within Cloudflare and Google Cloud free tiers. - (by bm1549)
 
 ## Client SDKs & API Wrappers
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -54,6 +54,11 @@
       author: Conner Burge
       github: https://github.com/ConnorDBurge/lunchmoney-mcp-v2
 
+    - name: lunchmoney-mcp-cloudflare
+      description: Deploys akutishevsky/lunchmoney-mcp to a Cloudflare Worker with Google OAuth, exposing it as a remote MCP server so the Claude mobile app (which can't use stdio servers) can connect as a custom connector. One-command setup wizard; fits within Cloudflare and Google Cloud free tiers.
+      author: bm1549
+      github: https://github.com/bm1549/lunchmoney-mcp-cloudflare
+
 - id: sdks
   icon: "🧱"
   title: Client SDKs & API Wrappers

--- a/generated/developer_tools.yml
+++ b/generated/developer_tools.yml
@@ -29,6 +29,12 @@
     description: MCP server built on the official Lunch Money v2 SDK.
     author: Conner Burge
     github: https://github.com/ConnorDBurge/lunchmoney-mcp-v2
+  - name: lunchmoney-mcp-cloudflare
+    description: Deploys akutishevsky/lunchmoney-mcp to a Cloudflare Worker with Google OAuth, exposing it as a remote MCP
+      server so the Claude mobile app (which can't use stdio servers) can connect as a custom connector. One-command setup
+      wizard; fits within Cloudflare and Google Cloud free tiers.
+    author: bm1549
+    github: https://github.com/bm1549/lunchmoney-mcp-cloudflare
 - id: sdks
   icon: 🧱
   title: Client SDKs & API Wrappers


### PR DESCRIPTION
Adds [lunchmoney-mcp-cloudflare](https://github.com/bm1549/lunchmoney-mcp-cloudflare) to the MCP Servers section. It's a thin deployment wrapper that hosts [akutishevsky/lunchmoney-mcp](https://github.com/akutishevsky/lunchmoney-mcp) on a Cloudflare Worker behind Google OAuth, so the Claude mobile app (which only supports remote custom connectors, not stdio) can use it. Setup is a single `./setup.sh` wizard and the whole thing fits in the Cloudflare and Google Cloud free tiers, which should make it accessible for non-developer Lunch Money users who want MCP access on their phone.

**Checklist:**
- [x] I edited `data/tools.yml`, not `README.md` directly (regenerated README + marketing yaml via `make generate`)
- [x] My entry has a `name` and `description`
- [x] I have added a link to the source code repo
- [x] The description is clear, concise, and non-promotional
- [x] I checked that this project is not already listed
- [x] I have read the [contribution guidelines](./contributing.md)

Thanks for maintaining the list!