### PR TITLE
[ENG-339] Update BBudget Try it URL to bbudget.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A quick note: V1 is still fully supported, but we recommend the [V2 API](https:/
 Access and manage your Lunch Money data on the go with these open source mobile apps. Or try [the official Lunch Money Mobile App](https://lunchmoney.app/download).
 
 * [BBudget](https://github.com/cleansoftlv/bbudget) - A fast, mobile-first companion web app. Provides simple UI for manual transaction input and review, perfect for less advanced users. - (by Alex Shakhov)
-  * [Try it](https://www.bbudget.com)
+  * [Try it](https://www.bbudget.app/)
   * [Spotlight Blog](https://lunchmoney.app/blog/2025-06-30-community-newsletter)
 * [Lunch Money Companion](https://github.com/Rodrigolmti/lunch_money_companion) - A companion Android application for Lunch Money, available on the Google Play Store. - (by Rodrigo Lopes)
   * [Google Play](https://play.google.com/store/apps/details?id=com.rodrigolmti.lunch.money.companion)

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -157,7 +157,7 @@
       author: Alex Shakhov
       lang: pwa
       github: https://github.com/cleansoftlv/bbudget
-      url: https://www.bbudget.com
+      url: https://www.bbudget.app/
       url_label: "Try it"
       spotlight: /blog/2025-06-30-community-newsletter
 

--- a/generated/developer_tools.yml
+++ b/generated/developer_tools.yml
@@ -85,7 +85,7 @@
     author: Alex Shakhov
     lang: pwa
     github: https://github.com/cleansoftlv/bbudget
-    url: https://www.bbudget.com
+    url: https://www.bbudget.app/
     url_label: Try it
     spotlight: /blog/2025-06-30-community-newsletter
   - name: Lunch Money Shortcuts


### PR DESCRIPTION
## Summary
- Update the BBudget "Try it" link to point to `https://www.bbudget.app/` instead of `https://www.bbudget.com`.
- Source edit lives in `data/tools.yml`; `README.md` and `generated/developer_tools.yml` were regenerated to match.

Reported by Dan — author's primary domain is now `.app`, so we should send traffic there.

Fixes ENG-339