### PR TITLE
Add seb-lunchmoney-sync (Enable Banking / PSD2 → Lunch Money)

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -299,7 +299,7 @@
       github: https://github.com/n3v3rf411/assorted-to-lunchmoney
 
     - name: seb-lunchmoney-sync
-      description: Sync European bank transactions to Lunch Money via Enable Banking (PSD2). Tested with SEB (Sweden); other supported banks are configuration.
+      description: Sync transactions from European banks to Lunch Money through Enable Banking (PSD2). Tested with SEB Sweden; other supported institutions can be configured.
       author: Daniel Grossfeld
       lang: python
       github: https://github.com/klokie/seb-lunchmoney-sync

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -298,6 +298,12 @@
       lang_label: TypeScript
       github: https://github.com/n3v3rf411/assorted-to-lunchmoney
 
+    - name: seb-lunchmoney-sync
+      description: Sync European bank transactions to Lunch Money via Enable Banking (PSD2). Tested with SEB (Sweden); other supported banks are configuration.
+      author: Daniel Grossfeld
+      lang: python
+      github: https://github.com/klokie/seb-lunchmoney-sync
+
   subsections:
     - title: Bookmarklets
       description: >-


### PR DESCRIPTION
Please check that your submission meets the [quality standards](./contributing.md#quality-standards) before sending a pull request. Thanks!

**Checklist:**
- [x] I edited `data/tools.yml`, not `README.md` directly
- [x] My entry has a `name` and `description`
- [x] I have added a link to the source code repo (or a `url` for non-GitHub projects)
- [x] The description is clear, concise, and non-promotional
- [x] I checked that this project is not already listed
- [x] I have read the [contribution guidelines](./contributing.md)

**Why should this be added?**

Transaction Import Tools currently covers Canada (RBC, TD, Wealthsimple), Chile (Fintoc), Singapore, Japan, the Netherlands and Apple Card. There is no entry for European open banking, and none for [Enable Banking](https://enablebanking.com) — a PSD2 account-information provider whose self-serve tier is free for personal use and which has strong Nordic coverage.

This fills that gap. It is closest in spirit to `lunchmoney-fintoc-sync`: run the aggregator layer yourself for banks Lunch Money has no native connection to, or where a managed sync is unreliable. The bank is configuration rather than code (`EB_ASPSP_NAME` / `EB_ASPSP_COUNTRY`), so it should work with any institution Enable Banking supports — though to be straightforward about scope, I have only tested it against SEB (Sweden).

It also handles a few things that are easy to get wrong when writing into an account that already has history:

- `sync-all` inserts only what Lunch Money lacks, matching on `external_id` and on (amount, payee) with a small date tolerance, because two providers routinely date the same transaction a day or two apart. Safe to run repeatedly.
- Pending transactions are skipped by default: they carry no stable id, so inserting one now means a duplicate when it books later.
- Consent expires (~90 days) and renewal needs interactive bank auth, so `check` reports days remaining rather than letting a scheduled job fail silently.

MIT licensed, documented, and in daily use.