### PR TITLE
Add lunchwidget (Android home-screen widget)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Access and manage your Lunch Money data on the go with these open source mobile 
   * [Try it](https://lunch-buddy.app/)
   * [Spotlight Blog](https://lunchmoney.app/blog/2026-02-10-community-newsletter)
   * [Discord](https://discord.com/channels/842337014556262411/1470488793391038485)
+* [lunchwidget](https://github.com/SauravSuresh/lunchwidget) - A home-screen widget showing an adaptive daily spending allowance (remaining budget divided by days left in the period), with two-tap quick add. Also handles split bills tagged per person, repayment matching, and account transfers. - (by Saurav Suresh)
 
 ## Transaction Import Tools
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -235,7 +235,7 @@
       discord: https://discord.com/channels/842337014556262411/1470488793391038485
 
     - name: lunchwidget
-      description: A home-screen widget showing an adaptive daily spending allowance (remaining budget divided by days left in the period), with two-tap quick add. Also handles split bills tagged per person, repayment matching, and account transfers.
+      description: An Android home-screen widget that turns the remaining monthly budget into an adaptive daily spending allowance and supports quick transaction entry, split bills, repayments, and account transfers.
       author: Saurav Suresh
       lang: android
       github: https://github.com/SauravSuresh/lunchwidget

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -234,6 +234,12 @@
       spotlight: /blog/2026-02-10-community-newsletter
       discord: https://discord.com/channels/842337014556262411/1470488793391038485
 
+    - name: lunchwidget
+      description: A home-screen widget showing an adaptive daily spending allowance (remaining budget divided by days left in the period), with two-tap quick add. Also handles split bills tagged per person, repayment matching, and account transfers.
+      author: Saurav Suresh
+      lang: android
+      github: https://github.com/SauravSuresh/lunchwidget
+
 - id: import-tools
   icon: "📥"
   title: Transaction Import Tools

--- a/generated/developer_tools.yml
+++ b/generated/developer_tools.yml
@@ -132,6 +132,13 @@
     url_label: Try it
     spotlight: /blog/2026-02-10-community-newsletter
     discord: https://discord.com/channels/842337014556262411/1470488793391038485
+  - name: lunchwidget
+    description: A home-screen widget showing an adaptive daily spending allowance (remaining budget divided by days left
+      in the period), with two-tap quick add. Also handles split bills tagged per person, repayment matching, and account
+      transfers.
+    author: Saurav Suresh
+    lang: android
+    github: https://github.com/SauravSuresh/lunchwidget
 - id: import-tools
   icon: 📥
   title: Transaction Import Tools


### PR DESCRIPTION
Please check that your submission meets the [quality standards](./contributing.md#quality-standards) before sending a pull request. Thanks!

**Checklist:**
- [x] I edited `data/tools.yml`, not `README.md` directly
- [x] My entry has a `name` and `description`
- [x] I have added a link to the source code repo (or a `url` for non-GitHub projects)
- [x] The description is clear, concise, and non-promotional
- [x] I checked that this project is not already listed
- [x] I have read the [contribution guidelines](./contributing.md)

**Why should this be added?**

[lunchwidget](https://github.com/SauravSuresh/lunchwidget) is an Android home-screen widget that answers one question at a glance — how much can I still spend today? It collapses the monthly budget into an adaptive daily allowance (remaining budget ÷ days left in the period), so the number self-corrects: overspend today and tomorrow shrinks.

The other half is logging. The whole widget is a button: tap → amount → category → save, roughly four seconds, without opening an app. It also covers split bills (owed portions post to an excluded Reimbursements category tagged `owed:<person>`, so only your share hits the budget), repayment matching against those pending tags, and transfers between accounts.

It complements the Android entry already on the list — Lunch Money Companion is a full companion app, while this is widget-only and focused on the daily-spend loop, so the two do not overlap much.

Notes for reviewers:

- Kotlin, minSdk 26, no runtime dependencies beyond AndroidX WorkManager. Talks straight to `dev.lunchmoney.app/v1` with a pasted token.
- API token, people list, and pending ledger are encrypted at rest with an Android Keystore key; backup and device-transfer are disabled.
- Unit tests cover the allowance math, split/itemize math, and the queued-write codec.
- Documented in the README, including the data model and the settings.
- I regenerated `README.md` and `generated/developer_tools.yml` with `scripts/generate_readme.py` and `scripts/export_marketing_yaml.py`; `scripts/validate_tools.py` passes (11 sections, 54 tools).

Thanks for the nudge, JP!